### PR TITLE
Update PentestMapper.py

### DIFF
--- a/PentestMapper.py
+++ b/PentestMapper.py
@@ -15,10 +15,10 @@ import javax.swing.Box
 from javax.swing.filechooser import FileNameExtensionFilter
 from java.awt.event import ActionListener
 from urlparse import urlparse
-import time, csv, sys, os
+import time, csv, sys, os, base64, zlib
 from threading import Thread, Event, Lock
 
-
+csv.field_size_limit(sys.maxsize)
 
 
 
@@ -744,12 +744,12 @@ class BurpExtender(IBurpExtender, ITab, IContextMenuFactory, AbstractTableModel,
                         SR = rows[0]
                         url = rows[1]
                         method = rows[2]
-                        body = rows[3]
+                        body =  zlib.decompress(base64.b64decode(rows[3]))
                         functionname = rows[4]
-                        request = rows[5]
+                        request =  zlib.decompress(base64.b64decode(rows[5]))
                         testcases = rows[6]
                         try:
-                            response = rows[7]
+                            response =  zlib.decompress(base64.b64decode(rows[7]))
                             status = rows[8]
                         except IndexError:
                             response = None
@@ -797,7 +797,7 @@ class BurpExtender(IBurpExtender, ITab, IContextMenuFactory, AbstractTableModel,
                     with open(fnameWithPath, 'wb') as loggerdata:
                         writer = csv.writer(loggerdata)
                         for logEntry in self._log:
-                            writer.writerow([str(logEntry._sr), str(logEntry._url) ,str(logEntry._method) ,str(logEntry._postbody) ,str(logEntry._FunctionalityName) ,str(logEntry._requestResponse) ,str(logEntry._TestCases),(logEntry._response).encode('utf-8').strip(),str(logEntry._status)])
+                            writer.writerow([str(logEntry._sr), str(logEntry._url) ,str(logEntry._method) , base64.b64encode(zlib.compress(logEntry._postbody.encode('utf-8'))) ,str(logEntry._FunctionalityName) , base64.b64encode(zlib.compress(logEntry._requestResponse.encode('utf-8'))) ,str(logEntry._TestCases), base64.b64encode(zlib.compress(logEntry._response.encode('utf-8'))) ,str(logEntry._status)])
                         loggerdata.close()
                         self.SingleclickexportMapper.setText("API Mapper Export Completed")
                 else:
@@ -1091,7 +1091,7 @@ class BurpExtender(IBurpExtender, ITab, IContextMenuFactory, AbstractTableModel,
             with open(fnameWithPath, 'wb') as loggerdata:
                 writer = csv.writer(loggerdata)
                 for logEntry in self._log:
-                    writer.writerow([str(logEntry._sr), str(logEntry._url) ,str(logEntry._method) ,str(logEntry._postbody) ,str(logEntry._FunctionalityName) ,str(logEntry._requestResponse) ,str(logEntry._TestCases),(logEntry._response).encode('utf-8').strip(),str(logEntry._status)])
+                    writer.writerow([str(logEntry._sr), str(logEntry._url) ,str(logEntry._method) , base64.b64encode(zlib.compress(logEntry._postbody.encode('utf-8'))) ,str(logEntry._FunctionalityName) , base64.b64encode(zlib.compress(logEntry._requestResponse.encode('utf-8'))) ,str(logEntry._TestCases), base64.b64encode(zlib.compress(logEntry._response.encode('utf-8'))) ,str(logEntry._status)])
             loggerdata.close()
 
 
@@ -1110,12 +1110,12 @@ class BurpExtender(IBurpExtender, ITab, IContextMenuFactory, AbstractTableModel,
                     SR = rows[0]
                     url = rows[1]
                     method = rows[2]
-                    body = rows[3]
+                    body = zlib.decompress(base64.b64decode(rows[3]))
                     functionname = rows[4]
-                    request = rows[5]
+                    request = zlib.decompress(base64.b64decode(rows[5]))
                     testcases = rows[6]
                     try:
-                        response = rows[7]
+                        response = zlib.decompress(base64.b64decode(rows[7]))
                         status = rows[8]
                     except IndexError:
                         response = None
@@ -1339,9 +1339,8 @@ class Autosaveclas(Thread):
                         with open(fnameWithPath, 'wb') as loggerdata:
                             writer = csv.writer(loggerdata)
                             for logEntry in self._handlingoutput._log:
-                            
-                                #self.callbacks.printOutput(str(logEntry._sr))
-                                writer.writerow([str(logEntry._sr), str(logEntry._url) ,str(logEntry._method) ,str(logEntry._postbody) ,str(logEntry._FunctionalityName) ,str(logEntry._requestResponse) ,str(logEntry._TestCases),(logEntry._response).encode('utf-8').strip(),str(logEntry._status)])
+                                writer.writerow([str(logEntry._sr), str(logEntry._url) ,str(logEntry._method) , base64.b64encode(zlib.compress(logEntry._postbody.encode('utf-8'))) ,str(logEntry._FunctionalityName) , base64.b64encode(zlib.compress(logEntry._requestResponse.encode('utf-8'))) ,str(logEntry._TestCases), base64.b64encode(zlib.compress(logEntry._response.encode('utf-8'))) ,str(logEntry._status)])
+                                 
                             loggerdata.close()
                     else:
                         self._handlingoutput.callbacks.printOutput("Skipping the API Mapper, Table is empty")


### PR DESCRIPTION
Fixed large inputs breaking csv output
Encode and compress original request and response to base64 to avoid issues with special characters breaking exported. This allows the ability to export binary related URLs if you disable the default 'App' or 'Image' exclusion